### PR TITLE
Remove golangci-lint v1 from release 1.34

### DIFF
--- a/.github/workflows/dispatch-pr-create.yml
+++ b/.github/workflows/dispatch-pr-create.yml
@@ -26,15 +26,7 @@ jobs:
         with:
           go-version: ${{ steps.get-ver.outputs.go_version }}
 
-      - name: Install golangci-lint v1
-        if: startsWith(steps.get-ver.outputs.golangci_version, 'v1')
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # SHA for v6.5.2
-        with:
-          args: --disable-all --timeout 5m # disable linting, initialize cache
-          version: ${{ steps.get-ver.outputs.golangci_version }}
-
       - name: Install golangci-lint v2
-        if: startsWith(steps.get-ver.outputs.golangci_version, 'v2')
         uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ steps.get-ver.outputs.golangci_version }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,14 +38,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.get-ver.outputs.go_version }}
-      - name: Install golangci-lint v1
-        if: startsWith(steps.get-ver.outputs.golangci_version, 'v1')
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # SHA for v6.5.2
-        with:
-          args: --disable-all --timeout 5m # disable linting, initialize cache
-          version: ${{ steps.get-ver.outputs.golangci_version }}
       - name: Install golangci-lint v2
-        if: startsWith(steps.get-ver.outputs.golangci_version, 'v2')
         uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ steps.get-ver.outputs.golangci_version }}


### PR DESCRIPTION
Logic was added to 1.34 so that workflows could be consistent across release-1.xx.  However, this is cause dependabot to be confused.  Doc says taht dependabot is not supposed to udpate SHA ... but it still is.

Simplist solution is to just remove golangci-lint v1 from release 1.34