### PR TITLE
Delete Calico datastore config (release 1.31)

### DIFF
--- a/ibm/ibm.go
+++ b/ibm/ibm.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * IBM Cloud Kubernetes Service, 5737-D43
-* (C) Copyright IBM Corp. 2017, 2025 All Rights Reserved.
+* (C) Copyright IBM Corp. 2017, 2026 All Rights Reserved.
 *
 * SPDX-License-Identifier: Apache2.0
 *
@@ -130,10 +130,6 @@ type CloudConfig struct {
 		// an in cluster config is not support for classic infrastructure
 		// since Calico does not support such configurations.
 		ConfigFilePaths []string `gcfg:"config-file"`
-		// The Calico datastore type: "ETCD" or "KDD". Required when running on
-		// classic infrastructure, otherwise this may be omitted and will be
-		// ignored for VPC infrastructure.
-		CalicoDatastore string `gcfg:"calico-datastore"`
 		// If set to true, all new nodes will get the condition NetworkUnavailable
 		// during node registration
 		SetNetworkUnavailable bool `gcfg:"set-network-unavailable,false"`
@@ -300,7 +296,6 @@ func NewCloud(config io.Reader) (cloudprovider.Interface, error) {
 		classicConfig := &classic.CloudConfig{
 			APIKeySecretPath:           c.Config.Prov.CloudCredentials,
 			Application:                c.Config.LBDeployment.Application,
-			CalicoDatastore:            c.Config.Kubernetes.CalicoDatastore,
 			ClusterID:                  c.Config.Prov.ClusterID,
 			ConfigFilePath:             c.Config.Kubernetes.ConfigFilePaths[0],
 			Region:                     c.Config.Prov.Region,

--- a/ibm/ibm_test.go
+++ b/ibm/ibm_test.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * IBM Cloud Kubernetes Service, 5737-D43
-* (C) Copyright IBM Corp. 2017, 2023 All Rights Reserved.
+* (C) Copyright IBM Corp. 2017, 2026 All Rights Reserved.
 *
 * SPDX-License-Identifier: Apache2.0
 *
@@ -118,10 +118,6 @@ func verifyCloudConfig(t *testing.T, cc *CloudConfig, ecc *CloudConfig) {
 		t.Fatalf("Unexpected cloud config k8s config file paths: %v, expected: %v", cc.Kubernetes.ConfigFilePaths, ecc.Kubernetes.ConfigFilePaths)
 	}
 
-	if !reflect.DeepEqual(ecc.Kubernetes.CalicoDatastore, cc.Kubernetes.CalicoDatastore) {
-		t.Fatalf("Unexpected calico datastore type: %v, expected: %v", cc.Kubernetes.CalicoDatastore, ecc.Kubernetes.CalicoDatastore)
-	}
-
 	if !reflect.DeepEqual(ecc.LBDeployment, cc.LBDeployment) {
 		t.Fatalf("Unexpected cloud config load balancer deployment: %v, expected: %v", cc.LBDeployment, ecc.LBDeployment)
 	}
@@ -142,7 +138,6 @@ func TestGetCloudConfig(t *testing.T) {
 	// Build expected cloud config.
 	ecc.Global.Version = "1.0.0"
 	ecc.Kubernetes.ConfigFilePaths = []string{"../test-fixtures/kubernetes/k8s-config"}
-	ecc.Kubernetes.CalicoDatastore = "KDD"
 	ecc.LBDeployment.Image = "registry.ng.bluemix.net/armada-master/keepalived:1328"
 	ecc.LBDeployment.Application = "keepalived"
 	ecc.LBDeployment.VlanIPConfigMap = "ibm-cloud-provider-vlan-ip-config"
@@ -170,7 +165,6 @@ func TestGetCloudConfig(t *testing.T) {
 		t.Fatalf("getCloudConfig failed for ibm-cloud-config-2.ini: %v", err)
 	}
 	ecc.Global.Version = "1.1.0"
-	ecc.Kubernetes.CalicoDatastore = ""
 	ecc.Prov.InternalIP = "10.190.31.186"
 	ecc.Prov.ExternalIP = "169.61.102.244"
 	ecc.Prov.Region = "testregion"
@@ -207,7 +201,6 @@ func TestGetCloudConfig(t *testing.T) {
 		t.Fatalf("getCloudConfig failed for ibm-cloud-config-ccm-classic.ini: %v", err)
 	}
 	// Build off previous expected configuration with select overrides.
-	ecc.Kubernetes.CalicoDatastore = "KDD"
 	verifyCloudConfig(t, cc, &ecc)
 
 	configccm, err = os.Open("../test-fixtures/ibm-cloud-config-ccm-vpc.ini")
@@ -220,7 +213,6 @@ func TestGetCloudConfig(t *testing.T) {
 		t.Fatalf("getCloudConfig failed for ibm-cloud-config-vpc.ini: %v", err)
 	}
 	// Build off previous expected configuration with select overrides.
-	ecc.Kubernetes.CalicoDatastore = ""
 	ecc.LBDeployment.Image = ""
 	ecc.LBDeployment.Application = ""
 	ecc.LBDeployment.VlanIPConfigMap = ""

--- a/pkg/classic/classic-config.go
+++ b/pkg/classic/classic-config.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * IBM Cloud Kubernetes Service, 5737-D43
-* (C) Copyright IBM Corp. 2017, 2024 All Rights Reserved.
+* (C) Copyright IBM Corp. 2017, 2026 All Rights Reserved.
 *
 * SPDX-License-Identifier: Apache2.0
 *
@@ -29,7 +29,6 @@ import (
 type CloudConfig struct {
 	APIKeySecretPath           string // File containing cloud credentials
 	Application                string // Name of the application to use as a label for the load balancer deployment
-	CalicoDatastore            string // The Calico datastore type: "ETCD" or "KDD"
 	ConfigFilePath             string // The Kubernetes config file path
 	ClusterID                  string // ClusterID
 	Region                     string // Region


### PR DESCRIPTION
(cherry picked from commit 3b0035de4d3e7c58704ee4e0934d0974b733629e)
