### PR TITLE
Fix CVE-2026-35469 bump spdystream to v0.5.1 (release-1.30)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,3 +123,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/moby/spdystream => github.com/moby/spdystream v0.5.1


### PR DESCRIPTION
# Fix for [CVE-2026-35469](https://nvd.nist.gov/vuln/detail/CVE-2026-35469)

## Summary
A validation flaw in moby/spdystream before v0.5.1 allows remote attackers to cause a Denial of Service (DoS) via an Out-of-Memory (OOM) crash.

## Description
The library's SPDY frame parser fails to validate length and count fields in incoming control frames before allocating memory. By sending a malicious frame (such as a crafted SETTINGS frame), an attacker can force the Go runtime to allocate massive memory arrays instantly, crashing the application.

## Fix
Version v0.5.1 fixes this by adding strict pre-allocation bounds checks on frame elements, setting maximum header limits, and immediately terminating connections upon encountering invalid control frames.